### PR TITLE
Add strftime formatting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Australia/Sydney     2023-12-12 04:37:13
   entries.
 - 🔒 _**Robust**_ - tested to work with all [tz database] entries,
   [`version 2023c`].
+- 🧭 _**Strftime-friendly**_ - accepts ISO C `strftime` with the common
+  extensions (e.g. `%C`, `%D`, `%G`, `%O*`, `%+`).
 - 📦 **Self-contained** - zero dependencies,
   lightweight (`110 lines`, `2458 bytes`).
 
@@ -67,9 +69,15 @@ Options:
   -h
       Print in human-readable format
   -s format
-      Set desired time format (e.g. "%Y-%m-%d")
+      Set desired strftime time format
+      (default "%Y-%m-%dT%H:%M:%S%z")
   -t timezone
       specific timezone (e.g. "Asia/Tokyo")
+
+Formatting uses ISO/IEC 9899 (`strftime`) with the usual extensions,
+including `%C`, `%D`, `%E*`, `%e`, `%G`, `%g`, `%h`, `%k`, `%l`, `%n`,
+`%O*`, `%R`, `%r`, `%s`, `%T`, `%t`, `%u`, `%V`, `%z`, and `%+`,
+powered by [`github.com/ncruces/go-strftime`](https://github.com/ncruces/go-strftime).
 
 Examples:
   Print Tokyo's date in a human-readable format with YY-MM-DD format:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module gotwc
 
 go 1.22.5
+
+require github.com/ncruces/go-strftime v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
+github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatTimeDefault(t *testing.T) {
+	loc := time.FixedZone("UTC", 0)
+	now := time.Date(2024, time.July, 12, 16, 3, 52, 0, loc)
+
+	got := formatTime(now, "%Y-%m-%dT%H:%M:%S%z")
+	want := "2024-07-12T16:03:52+0000"
+	if got != want {
+		t.Fatalf("formatTime() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatTimeExtensions(t *testing.T) {
+	loc := time.FixedZone("TEST", 2*60*60)
+	now := time.Date(2024, time.March, 5, 14, 3, 2, 0, loc)
+
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{"%C", "20"},
+		{"%D", "03/05/24"},
+		{"%e", " 5"},
+		{"%G", "2024"},
+		{"%g", "24"},
+		{"%h", "Mar"},
+		{"%k", "14"},
+		{"%l", " 2"},
+		{"%n", "\n"},
+		{"%Oe", " 5"},
+		{"%R", "14:03"},
+		{"%r", "02:03:02 PM"},
+		{"%s", "1709640182"},
+		{"%T", "14:03:02"},
+		{"%t", "\t"},
+		{"%u", "2"},
+		{"%V", "10"},
+		{"%z", "+0200"},
+		{"%+", "Tue Mar  5 14:03:02 TEST 2024"},
+	}
+
+	for _, tt := range tests {
+		got := formatTime(now, tt.format)
+		if got != tt.want {
+			t.Fatalf(
+				"formatTime(%q) = %q, want %q",
+				tt.format, got, tt.want,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3

Started using [github.com/ncruces/go-strftime](https://github.com/ncruces/go-strftime) for C-like `strftime()` support (incl. `%E`/`%O` etc.).

Set some default format/docs accordingly and added tests to avoid regressions.
